### PR TITLE
Some fixes related to the data writing state machine

### DIFF
--- a/picopythonhub75.py
+++ b/picopythonhub75.py
@@ -4,6 +4,8 @@ from machine import Pin
 import array
 import math
 import _thread
+import random
+
 #TODO
 #* work out how to place pixels in different places
 #* buffering??
@@ -61,14 +63,6 @@ def row_hub75():
 #can I run them at full tilt, or do they need slowing down?
 sm_data = rp2.StateMachine(0,data_hub75, out_base=Pin(data_pin_start), sideset_base=Pin(clock_pin), freq=55000000)
 sm_row = rp2.StateMachine(1, row_hub75, out_base=Pin(row_pin_start),sideset_base=Pin(latch_pin_start), freq=1000000)
-
-#note - L is unsigned long - 32 bits. 
-a_rows = array.array("I", [0xffff, 0xffff]) # try and put some row data in there?
-a_data = array.array("I", [0xffff for _ in range(row_ar_len)])
-
-#test, let's make everything white (note - I have a good power supply!)
-#for i in range(row_ar_len):
-#    a_data[i] = 0x1000 # chuck some data in and work it out later
     
 sm_row.active(1)
 sm_data.active(1)
@@ -77,15 +71,17 @@ counter = 0
 
 toggle = False
 
-#data format
-#-- send data in 24-bit blocks
-# 8 24 bit blocks per 'row'
-#how many 'rows'? 15? 16?
-#data is sequential rgb bits
-
 rows = []
-blocks_per_row = 8 #each block has 24 bits, so 4 pixels x 2 scanlines
-num_rows = 16
+blocks_per_row = const(8) #each block has 24 bits, so 4 pixels x 2 scanlines
+num_rows = const(16)
+
+fast_buffer1 = array.array("I")
+fast_buffer2 = array.array("I")
+for i in range(blocks_per_row * num_rows):
+    fast_buffer1.append(0)
+    fast_buffer2.append(0)
+drawBuffer = fast_buffer1
+frameBuffer = fast_buffer2
 
 #fill with white
 '''
@@ -110,18 +106,28 @@ for j in range(num_rows):
 # 2nd pixel 16th scanline would be the next lowest bits (9-11)
 # continue this pattern to fill our 24-bits
 
-def set_pixel(x, y, red, green, blue):
+@micropython.viper
+def set_pixel(x:int, y:int, rgb:uint):
 
-    bit_posn = ((x % 4)) * 6
+    bit_posn = ((x % 4) * 6)
     if y > 15:
-        y = y - 16
+        y = y - 17
         bit_posn += 3
+    else:
+        y = y - 1
 
-    rgb = (red << 0) | (green << 1) | (blue << 2);
-    rows[y - 1][int(x / 4)] |= rgb << (bit_posn)
+    # a mystery but rows 0/16 need to use y = 15 to be drawn correctly
+    if y == -1:
+        y = 15
+
+    index = y * blocks_per_row + int(x >> 2)
+    val = uint(drawBuffer[index])
+
+    drawBuffer[index] = val | uint(rgb << (bit_posn))
         
 def light_xy(x,y, r, g, b):
-    set_pixel(x, y, r, g, b)
+    rgb = (r << 0) | (g << 1) | (b << 2);
+    set_pixel(x, y, rgb)
     
 #p-shape
 #should these really be stored as datapoints?
@@ -157,6 +163,15 @@ def o_draw(init_x, init_y, r, g, b):
         light_xy(init_x+1+i, init_y, r, g, b)
         light_xy(init_x+1+i, init_y+5, r, g, b)
 
+def clearBuffer():
+    # reusing should be same or faster than reallocations
+    #for j in range(num_rows):
+    #    for i in range(blocks_per_row):
+    #        rows[j][i] = 0
+
+    for i in range(num_rows * blocks_per_row):
+         drawBuffer[i] = 0
+
 text_y = 14
 direction = 1
 
@@ -172,11 +187,7 @@ def draw_text():
     if text_y > 20: direction = -1
     if text_y < 5: direction = 1
 
-    rows = [0]*num_rows
-
-    #fill with black
-    for j in range(num_rows):
-        rows[j] = [0]*blocks_per_row
+    clearBuffer()
             
     p_draw(3, text_y-4, 1, 1, 1)
     i_draw(9, text_y, 1, 1, 0)
@@ -184,14 +195,35 @@ def draw_text():
     o_draw(16, text_y, 1, 0, 1)
     writing = False
     
-draw_text()
+#draw_text()
 draw_counter = 0
-
-#going to need double-buffering
 
 writing = False
 
 out_rows = rows
+
+def draw_performance():
+    global writing
+    global rows
+
+    writing = True
+
+    start = time.ticks_us()
+
+    counter = random.randint(1, 7);
+
+    clearBuffer()
+
+    for j in range(32):
+        for i in range(32):
+            set_pixel(i, j, 1 + counter % 6)
+            counter += 1
+
+    end = time.ticks_us()
+    usecs = time.ticks_diff(end, start)
+    print(usecs / 1000.0)
+
+    writing = False
 
 def draw_test_pattern():
     global writing
@@ -199,17 +231,13 @@ def draw_test_pattern():
 
     writing = True
 
-    rows = [0]*num_rows
-
-    #fill with black
-    for j in range(num_rows):
-        rows[j] = [0]*blocks_per_row
+    clearBuffer()
 
     for i in range(0,32):
         # draw random selection of rows/colums using all colors
-        light_xy(i, 20, 0, 0, 1)
-        light_xy(i, 1, 0, 1, 0)
-        light_xy(i, 30, 0, 1, 1)
+        light_xy(i, 31, 0, 0, 1)
+        light_xy(i, 0, 0, 1, 0)
+        light_xy(i, 16, 0, 1, 1)
         light_xy(0, i, 1, 0, 0)
         light_xy(5, i, 1, 0, 1)
         light_xy(15, i, 1, 1, 0)
@@ -223,13 +251,20 @@ while(True):
     sm_row.put(counter)
 
     # Write out 8 integers that hold 8 pixels worth of 3-bit RGB (two scanlines x four pixels)
-    for i in range(blocks_per_row):
-        sm_data.put(out_rows[counter][i])
+    baseIndex = counter * 8
+    for i in range(8):
+        val = frameBuffer[baseIndex + i]
+        sm_data.put(val)
+        #sm_data.put(out_rows[counter][i])
 
     counter = counter +1
     if (counter > 15):
         counter = 0
         if writing == False:
-            out_rows = rows.copy()
+
+            # perform our double buffering
+            tempBuffer = frameBuffer
+            frameBuffer = drawBuffer
+            drawBuffer = tempBuffer
             _thread.start_new_thread(draw_text, ())
 


### PR DESCRIPTION
* We really only need to send 12-bits at a time with the current pixel format
* We should pulse our clock signal after setting each 6 bits
* We only need to write out 16 12-bit values to fill 2 32 pixel rows
* Add a simple test routine which flickers badly with the prior state machine

In general, the addressing is drawing the input rotated on the 32x32 LED board. I have a future implementation that generates far simpler pixel data to use for sm_data where we could send 24 bits at a time.